### PR TITLE
Fix non-idiomatic variable pattern in worker?/0

### DIFF
--- a/lib/ex_fdbmonitor/application.ex
+++ b/lib/ex_fdbmonitor/application.ex
@@ -37,7 +37,7 @@ defmodule ExFdbmonitor.Application do
   defp worker?() do
     case {Application.fetch_env(:ex_fdbmonitor, :etc_dir),
           Application.fetch_env(:ex_fdbmonitor, :run_dir)} do
-      {{ok, _}, {ok, _}} ->
+      {{:ok, _}, {:ok, _}} ->
         true
 
       _ ->


### PR DESCRIPTION
Replace `{ok, _}` with `{:ok, _}` in the case match inside `worker?/0`.
Using a variable name `ok` instead of the atom `:ok` is confusing and
non-idiomatic; the intent is to match the `{:ok, value}` return from
`Application.fetch_env/2`.

https://claude.ai/code/session_01ENEhZiWqG6hoX58kfpAKEA